### PR TITLE
Require minimum lobstr version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ LazyData: true
 Imports: 
     purrr,
     rlang,
-    lobstr,
+    lobstr (>= 1.1.1),
     tibble (>= 2.1.1),
     usethis,
     fs,


### PR DESCRIPTION
Since lower versions don't have the `sxp()` functions and break with lm objects