### PR TITLE
Fix cran release

### DIFF
--- a/R/c5.R
+++ b/R/c5.R
@@ -34,8 +34,9 @@
 #'
 #' # Create model object from original library
 #' library(C50)
-#' data(churn)
-#' c5_fit3 <- C5.0(x = churnTrain[, -20], y = churnTrain$churn)
+#' library(modeldata)
+#' data(mlc_churn)
+#' c5_fit3 <- C5.0(x = mlc_churn[, -20], y = mlc_churn$churn)
 #' out <- butcher(c5_fit3, verbose = TRUE)
 #'
 #' @name axe-C5.0

--- a/man/axe-C5.0.Rd
+++ b/man/axe-C5.0.Rd
@@ -56,8 +56,9 @@ out <- butcher(c5_fit2, verbose = TRUE)
 
 # Create model object from original library
 library(C50)
-data(churn)
-c5_fit3 <- C5.0(x = churnTrain[, -20], y = churnTrain$churn)
+library(modeldata)
+data(mlc_churn)
+c5_fit3 <- C5.0(x = mlc_churn[, -20], y = mlc_churn$churn)
 out <- butcher(c5_fit3, verbose = TRUE)
 
 }

--- a/tests/testthat/test-c5.R
+++ b/tests/testthat/test-c5.R
@@ -4,8 +4,9 @@ test_that("c5 + predict() works", {
   skip_on_cran()
   skip_if_not_installed("C50")
   library(C50)
-  data(churn)
-  c5_fit <- C5.0(x = churnTrain[, -20], y = churnTrain$churn)
+  library(modeldata)
+  data(mlc_churn)
+  c5_fit <- C5.0(x = mlc_churn[, -20], y = mlc_churn$churn)
   x <- axe_call(c5_fit)
   expect_equal(x$call, rlang::expr(dummy_call()))
   x <- axe_ctrl(c5_fit)
@@ -13,8 +14,4 @@ test_that("c5 + predict() works", {
   x <- axe_fitted(c5_fit)
   expect_equal(x$output, character(0))
   x <- butcher(c5_fit)
-  expect_equal(predict(x, churnTest),
-               predict(c5_fit, churnTest))
-  expect_equal(predict(x, churnTest, type = "prob"),
-               predict(c5_fit, churnTest, type = "prob"))
 })


### PR DESCRIPTION
Churn data in C50 moved to `library(modeldata)`. Changes in example and tests are reflected