### PR TITLE
new tidymodels.org url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Authors@R: c(
            email = "alexpghayes@gmail.com"))
 Description: Provides a set of five S3 generics to axe components of fitted model objects and help reduce the size of model objects saved to disk.
 License: MIT + file LICENSE
-URL: https://tidymodels.github.io/butcher, https://github.com/tidymodels/butcher
+URL: https://tidymodels.github.io/butcher, https://butcher.tidymodels.org
 BugReports: https://github.com/tidymodels/butcher/issues
 Encoding: UTF-8
 LazyData: true

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,9 +1,11 @@
+url: https://butcher.tidymodels.org
+
 destination: docs
 
 template:
   package: tidytemplate
   params:
-    part_of: <a href="https://github.com/tidymodels">tidymodels</a>
+    part_of: <a href="url: https://tidymodels.org">tidymodels</a>
     footer: butcher is a part of the <strong>tidymodels</strong> ecosystem, a collection of modeling packages designed with common APIs and a shared philosophy.
 
 development:


### PR DESCRIPTION
Once I get the CNAME entry changed, we can merge this and use the new url. I'll update here when the PR can be merged. 

It will also require 3 manual changes to the repos settings after merge:

 * change the website settings on the repo's front page
 * change `Settings : GitHub Pages : Custom domain`
 * change `Settings : GitHub Pages : Enforce HTTPS`