### PR TITLE
Move `modeldata` from Imports to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,7 @@ Imports:
     usethis (>= 1.5.0),
     fs,
     utils,
-    methods,
-    modeldata
+    methods
 RoxygenNote: 7.1.1
 Suggests: 
     clisymbols,
@@ -71,7 +70,8 @@ Suggests:
     pls,
     fastICA,
     RSpectra,
-    RANN
+    RANN,
+    modeldata
 Depends: 
     R (>= 3.1)
 VignetteBuilder: knitr


### PR DESCRIPTION
It is only used for tests and examples. CRAN gives us a NOTE about this:

```r
Version: 0.1.2
Check: dependencies in R code
Result: NOTE
    Namespace in Imports field not imported from: ‘modeldata’
     All declared Imports should be used.
```