### PR TITLE
Fix usage of frailty terms in survreg() dummy examples

### DIFF
--- a/R/survreg.penal.R
+++ b/R/survreg.penal.R
@@ -17,15 +17,14 @@
 #' # Create model and fit
 #' survreg_fit <- surv_reg(mode = "regression", dist = "weibull") %>%
 #'   set_engine("survival") %>%
-#'   fit(Surv(time, status) ~ rx + frailty.gaussian(litter, df = 13), data = rats)
+#'   fit(Surv(time, status) ~ rx, data = rats)
 #'
 #' out <- butcher(survreg_fit, verbose = TRUE)
 #'
 #' # Another survreg.penal object
 #' wrapped_survreg.penal <- function() {
 #'   some_junk_in_environment <- runif(1e6)
-#'   fit <- survreg(Surv(time, status) ~ rx +
-#'                    frailty.gaussian(litter, df = 13, sparse = FALSE),
+#'   fit <- survreg(Surv(time, status) ~ rx,
 #'                  data = rats, subset = (sex == "f"))
 #'   return(fit)
 #' }

--- a/man/axe-survreg.penal.Rd
+++ b/man/axe-survreg.penal.Rd
@@ -39,15 +39,14 @@ suppressWarnings(library(lobstr))
 # Create model and fit
 survreg_fit <- surv_reg(mode = "regression", dist = "weibull") \%>\%
   set_engine("survival") \%>\%
-  fit(Surv(time, status) ~ rx + frailty.gaussian(litter, df = 13), data = rats)
+  fit(Surv(time, status) ~ rx, data = rats)
 
 out <- butcher(survreg_fit, verbose = TRUE)
 
 # Another survreg.penal object
 wrapped_survreg.penal <- function() {
   some_junk_in_environment <- runif(1e6)
-  fit <- survreg(Surv(time, status) ~ rx +
-                   frailty.gaussian(litter, df = 13, sparse = FALSE),
+  fit <- survreg(Surv(time, status) ~ rx,
                  data = rats, subset = (sex == "f"))
   return(fit)
 }

--- a/tests/testthat/test-survreg.penal.R
+++ b/tests/testthat/test-survreg.penal.R
@@ -4,8 +4,11 @@ test_that("survreg + penalized + predict() works", {
   skip_on_cran()
   skip_if_not_installed("survival")
   library(survival)
-  fit <- survreg(Surv(time, status) ~ rx + frailty.gaussian(litter, df = 13, sparse = FALSE),
-                 data = rats, subset = (sex == "f"))
+  fit <- survreg(
+    Surv(time, status) ~ rx,
+    data = rats,
+    subset = (sex == "f")
+  )
   x <- axe_call(fit)
   expect_equal(x$call, rlang::expr(dummy_call()))
   x <- axe_data(fit)


### PR DESCRIPTION
Closes #184 

survival 3.2-9 now errors when this is used incorrectly. Their NEWS bullet says:

"Add an explicit error message for survreg() with a frailty term. This usage was never supported – it is integrating out the appropriate density for a coxph model, which is the wrong one for survreg – but because the code would run we've found that people assumed it must be right, despite a statement to the contrary in the survival vignette. Long overdue fix."