### PR TITLE
Avoid warning when trying to load veteran with `data(veteran)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,7 @@ Suggests:
     rpart,
     rsample,
     RSpectra,
-    survival,
+    survival (>= 3.2-10),
     testthat (>= 2.1.0),
     TH.data,
     xgboost (>= 1.3.2.1)

--- a/tests/testthat/test-ranger.R
+++ b/tests/testthat/test-ranger.R
@@ -54,7 +54,6 @@ test_that("ranger + survival option works", {
   skip_if_not_installed("survival")
   library(ranger)
   library(survival)
-  data(veteran)
   rg.veteran <- ranger(Surv(time, status) ~ ., data = veteran)
   x <- butcher(rg.veteran)
   expect_equal(timepoints(x),


### PR DESCRIPTION
It seems to be loaded by survival automatically. Just to be safe, we now suggest a minimum of the current CRAN version of survival in case this was a recent change.