### PR TITLE
Remove themis related tests

### DIFF
--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -422,13 +422,6 @@ test_that("recipe + step_window + axe_env() works", {
   terms_empty_env(x, 1)
 })
 
-test_that("recipe + step_upsample + axe_env() works", {
-  rec <- recipe( ~ ., data = okc) %>%
-    step_upsample(diet, ratio = 0.0121)
-  x <- axe_env(rec)
-  terms_empty_env(x, 1)
-})
-
 test_that("recipe + step_unorder + axe_env() works", {
   rec <- recipe(HHV ~ ., data = biomass_tr) %>%
     step_unorder(all_predictors())
@@ -513,13 +506,6 @@ test_that("recipe + step_corr + axe_env() works", {
 test_that("recipe + step_depth + axe_env() works", {
   rec <- recipe(Species ~ ., data = iris) %>%
     step_depth(all_predictors(), class = "Species")
-  x <- axe_env(rec)
-  terms_empty_env(x, 1)
-})
-
-test_that("recipe + step_downsample + axe_env() works", {
-  rec <- recipe( ~ ., data = okc) %>%
-    step_downsample(diet)
   x <- axe_env(rec)
   terms_empty_env(x, 1)
 })


### PR DESCRIPTION
Closes #154 

Since we now default to stripping the terms of all recipe steps by default, we don't need to be as strict with testing here.

Since they have moved to themis and will be removed from recipes, it is more pain than it is worth to keep them here.
