### PR TITLE
Fix painful dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,6 @@ Suggests:
     dplyr,
     e1071,
     earth,
-    fastICA,
     flexsurv,
     ipred,
     kernlab,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,6 @@ Suggests:
     MASS,
     mda,
     modeldata,
-    NMF,
     nnet,
     parsnip (>= 0.1.6),
     pkgload,

--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -510,13 +510,6 @@ test_that("recipe + step_depth + axe_env() works", {
   terms_empty_env(x, 1)
 })
 
-test_that("recipe + step_ica + axe_env() works", {
-  rec <- recipe(Species ~ ., data = iris) %>%
-    step_ica(Petal.Width, Sepal.Width, num_comp = 2)
-  x <- axe_env(rec)
-  terms_empty_env(x, 1)
-})
-
 test_that("recipe + step_isomap + axe_env() works", {
   rec <- recipe(HHV ~ ., data = biomass_tr) %>%
     step_isomap(all_predictors(), neighbors = 5, num_terms = 2)

--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -397,13 +397,6 @@ test_that("recipe + step_slice + axe_env() works", {
   inputs_empty_env(x, 1)
 })
 
-test_that("recipe + step_nnmf + axe_env() works", {
-  rec <- recipe(HHV ~ ., data = biomass_tr) %>%
-    step_nnmf(all_predictors(), num_comp = 2, seed = 473, num_run = 2)
-  x <- axe_env(rec)
-  terms_empty_env(x, 1)
-})
-
 test_that("recipe + step_zv + axe_env() works", {
   rec <- recipe(HHV ~ ., data = biomass_tr) %>%
     step_zv(all_predictors())


### PR DESCRIPTION
Closes #201 

- Removes NMF because it is from Bioconductor and sometimes hard to install
- Removes fastICA because it is R >=4.0.0 and recipes is dropping it anyways