### PR TITLE
Update two tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,8 @@ jobs:
         with:
           extra-packages:
             any::rcmdcheck,
-            randomForest=?ignore-before-r=4.1.0
+            randomForest=?ignore-before-r=4.1.0,
+            flexsurv=?ignore-before-r=4.0.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,4 @@ Config/Needs/website:
     tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@
 
 * Added butcher methods for `glm()` (#212).
 
+* Preemptively fixed a test related to a recipes change in `step_hyperbolic()` 
+  (#220).
+
 # butcher 0.1.5
 
 * Added an `axe_env()` method to remove the `terms` environment for recipe

--- a/R/flexsurvreg.R
+++ b/R/flexsurvreg.R
@@ -10,8 +10,7 @@
 #'
 #' @return Axed flexsurvreg object.
 #'
-#' @examples
-#' \donttest{
+#' @examplesIf rlang::is_installed("flexsurv")
 #' # Load libraries
 #' suppressWarnings(suppressMessages(library(parsnip)))
 #' suppressWarnings(suppressMessages(library(flexsurv)))
@@ -32,7 +31,6 @@
 #' }
 #'
 #' out <- butcher(wrapped_flexsurvreg(), verbose = TRUE)
-#' }
 #' @name axe-flexsurvreg
 NULL
 

--- a/man/axe-flexsurvreg.Rd
+++ b/man/axe-flexsurvreg.Rd
@@ -30,7 +30,7 @@ leverage distributions like the generalized gamma, generalized F, and
 the Royston-Parmar spline model.
 }
 \examples{
-\donttest{
+\dontshow{if (rlang::is_installed("flexsurv")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Load libraries
 suppressWarnings(suppressMessages(library(parsnip)))
 suppressWarnings(suppressMessages(library(flexsurv)))
@@ -51,5 +51,5 @@ wrapped_flexsurvreg <- function() {
 }
 
 out <- butcher(wrapped_flexsurvreg(), verbose = TRUE)
-}
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/helper-recipes.R
+++ b/tests/testthat/helper-recipes.R
@@ -11,3 +11,10 @@ skip_if_recipes_post_0.1.16 <- function() {
     message = "Skipping on new recipes where no longer applicable (post 0.1.16)"
   )
 }
+
+skip_if_recipes_pre_0.2.1 <- function() {
+  skip_if(
+    condition = packageVersion("recipes") < "0.2.0.9001",
+    message = "Skipping on old recipes (pre 0.2.1)"
+  )
+}

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -1,5 +1,3 @@
-context("glm")
-
 test_that("glm + axe_call() works", {
   glm_fit <- glm(mpg ~ ., data = mtcars)
   x <- axe_call(glm_fit)

--- a/tests/testthat/test-recipe.R
+++ b/tests/testthat/test-recipe.R
@@ -118,8 +118,9 @@ test_that("recipe + step_bs + axe_env() works", {
 })
 
 test_that("recipe + step_hyperbolic + axe_env() works", {
+  skip_if_recipes_pre_0.2.1()
   rec <- recipe(~ ., data = as.data.frame(state.x77)) %>%
-    step_hyperbolic(Income, func = "cos", inverse = FALSE)
+    step_hyperbolic(Income, func = "cosh", inverse = FALSE)
   x <- axe_env(rec)
   terms_empty_env(x, 1)
 })


### PR DESCRIPTION
This PR updates two tests:

- remove one extract `context()` that didn't get caught in #216 
- update test for `step_hyperbolic()`, related to tidymodels/recipes#932

The second test is a revdep failure for recipes, so butcher will probably need to go to CRAN before recipes does.