### PR TITLE
Remove extra "B" in `memory_released()` printing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           extra-packages:
             any::rcmdcheck,
+            any::XML,
             randomForest=?ignore-before-r=4.1.0,
             flexsurv=?ignore-before-r=4.0.0
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,8 +55,8 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        pak-version: devel
         with:
+          pak-version: devel
           extra-packages:
             any::rcmdcheck,
             randomForest=?ignore-before-r=4.1.0,

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           extra-packages:
             any::rcmdcheck,
-            any::XML,
+            XML,
             randomForest=?ignore-before-r=4.1.0,
             flexsurv=?ignore-before-r=4.0.0
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,11 +54,8 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install sfsmisc (for ddalpha)
-        run: install.packages("sfsmisc")
-        shell: Rscript {0}
-
       - uses: r-lib/actions/setup-r-dependencies@v2
+        pak-version: devel
         with:
           extra-packages:
             any::rcmdcheck,

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,11 +54,14 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Install sfsmisc (for ddalpha)
+        run: install.packages("sfsmisc")
+        shell: Rscript {0}
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages:
             any::rcmdcheck,
-            any::cpp11,
             randomForest=?ignore-before-r=4.1.0,
             flexsurv=?ignore-before-r=4.0.0
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           extra-packages:
             any::rcmdcheck,
-            XML,
+            any::cpp11,
             randomForest=?ignore-before-r=4.1.0,
             flexsurv=?ignore-before-r=4.0.0
           needs: check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
     R (>= 3.4.0)
 Imports: 
     cli (>= 3.3.0),
-    lobstr (>= 1.1.1),
+    lobstr (>= 1.1.2),
     methods,
     purrr (>= 0.3.4),
     rlang (>= 1.0.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # butcher (development version)
 
+* Updated printing for `memory_released()` (#229).
+
 # butcher 0.2.0
 
 * Added an `axe_fitted()` method to butcher the `template` slot for prepped 

--- a/R/ui.R
+++ b/R/ui.R
@@ -20,7 +20,7 @@ memory_released <- function(og, butchered) {
     if (rel <= 0) {
       return(NULL)
     } else {
-      return(paste(rel, "B"))
+      return(rel)
     }
   } else {
     return(NULL)


### PR DESCRIPTION
With the current default branch, we get an extra "B" with `verbose = TRUE`:

``` r
library(butcher)
cars_glm <- glm(mpg ~ ., data = mtcars)
x <- butcher(cars_glm, verbose = TRUE)
#> ✔ Memory released: "6.84 kB B"
#> ✖ Disabled: `print()`, `summary()`, `fitted()`, and `residuals()`
```

<sup>Created on 2022-08-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This PR removes the extra "B":

``` r
library(butcher)
cars_glm <- glm(mpg ~ ., data = mtcars)
x <- butcher(cars_glm, verbose = TRUE)
#> ✔ Memory released: "6.84 kB"
#> ✖ Disabled: `print()`, `summary()`, `fitted()`, and `residuals()`
```

<sup>Created on 2022-08-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>