### PR TITLE
remove hat and offset vectors in axe_fitted.gam

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# butcher (development version)
+
+* Updated methods for `mgcv::gam()` to also remove the `hat` and `offset` 
+  components (@rdavis120, #255).
+
 # butcher 0.3.2
 
 * Added butcher methods for `mixOmics::pls()`, `mixOmics::spls()`, 

--- a/R/gam.R
+++ b/R/gam.R
@@ -96,6 +96,8 @@ axe_fitted.gam <- function(x, verbose = FALSE, ...) {
   x <- exchange(x, "fitted.values", numeric(0))
   x <- exchange(x, "residuals", numeric(0))
   x <- exchange(x, "linear.predictors", numeric(0))
+  x <- exchange(x, "hat", numeric(0))
+  x <- exchange(x, "offset", numeric(0))
 
   add_butcher_attributes(
     x,

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -43,8 +43,25 @@ test_that("gam + predict() works", {
     predict(gam_fit, newdata = head(mtcars))[1]
   )
   expect_equal(
-    predict(x, newdata = head(mtcars), type = "terms")[1,],
-    predict(gam_fit, newdata = head(mtcars), type = "terms")[1,]
+    predict(x, newdata = head(mtcars), type = "terms")[1, ],
+    predict(gam_fit, newdata = head(mtcars), type = "terms")[1, ]
+  )
+  expect_equal(
+    predict(x, newdata = head(mtcars), se.fit = TRUE)$se.fit[1],
+    predict(gam_fit, newdata = head(mtcars), se.fit = TRUE)$se.fit[1]
+  )
+})
+
+test_that("gam + predict() works with offset", {
+  gam_fit <- mgcv::gam(mpg ~ s(disp, k = 3) + s(wt), data = mtcars, offset = seq(1, nrow(mtcars)))
+  x <- butcher(gam_fit)
+  expect_equal(
+    predict(x, newdata = head(mtcars))[1],
+    predict(gam_fit, newdata = head(mtcars))[1]
+  )
+  expect_equal(
+    predict(x, newdata = head(mtcars), type = "terms")[1, ],
+    predict(gam_fit, newdata = head(mtcars), type = "terms")[1, ]
   )
   expect_equal(
     predict(x, newdata = head(mtcars), se.fit = TRUE)$se.fit[1],


### PR DESCRIPTION
The hat and offset vectors can be removed since they are not required for predictions, and are the only objects not currently removed that have a length equal to nrow(data). This will be a significant reduction in object size if nrow(data) is large.

