### PR TITLE
Fix argument name for `initial_split()`

### DIFF
--- a/R/c5.R
+++ b/R/c5.R
@@ -16,7 +16,7 @@
 #'
 #' # Load data
 #' set.seed(1234)
-#' split <- initial_split(kyphosis, props = 9/10)
+#' split <- initial_split(kyphosis, prop = 9/10)
 #' spine_train <- training(split)
 #'
 #' # Create model and fit

--- a/R/elnet.R
+++ b/R/elnet.R
@@ -13,7 +13,7 @@
 #' library(rsample)
 #'
 #' # Load data
-#' split <- initial_split(mtcars, props = 9/10)
+#' split <- initial_split(mtcars, prop = 9/10)
 #' car_train <- training(split)
 #'
 #' # Create model and fit

--- a/R/kknn.R
+++ b/R/kknn.R
@@ -17,7 +17,7 @@
 #'
 #' # Load data
 #' set.seed(1234)
-#' split <- initial_split(kyphosis, props = 9/10)
+#' split <- initial_split(kyphosis, prop = 9/10)
 #' spine_train <- training(split)
 #'
 #' # Create model and fit

--- a/R/lm.R
+++ b/R/lm.R
@@ -12,7 +12,7 @@
 #' library(rsample)
 #'
 #' # Load data
-#' split <- initial_split(mtcars, props = 9/10)
+#' split <- initial_split(mtcars, prop = 9/10)
 #' car_train <- training(split)
 #'
 #' # Create model and fit

--- a/R/randomForest.R
+++ b/R/randomForest.R
@@ -18,7 +18,7 @@
 #'
 #' # Load data
 #' set.seed(1234)
-#' split <- initial_split(kyphosis, props = 9/10)
+#' split <- initial_split(kyphosis, prop = 9/10)
 #' spine_train <- training(split)
 #'
 #' # Create model and fit

--- a/R/ranger.R
+++ b/R/ranger.R
@@ -20,7 +20,7 @@
 #'
 #' # Load data
 #' set.seed(1234)
-#' split <- initial_split(iris, props = 9/10)
+#' split <- initial_split(iris, prop = 9/10)
 #' iris_train <- training(split)
 #'
 #' # Create model and fit

--- a/R/rpart.R
+++ b/R/rpart.R
@@ -16,7 +16,7 @@
 #'
 #' # Load data
 #' set.seed(1234)
-#' split <- initial_split(mtcars, props = 9/10)
+#' split <- initial_split(mtcars, prop = 9/10)
 #' car_train <- training(split)
 #'
 #' # Create model and fit

--- a/inst/extdata-scripts/c5.R
+++ b/inst/extdata-scripts/c5.R
@@ -5,7 +5,7 @@ suppressWarnings(suppressMessages(library(rpart)))
 
 # Load data
 set.seed(1234)
-split <- initial_split(kyphosis, props = 9/10)
+split <- initial_split(kyphosis, prop = 9/10)
 spine_train <- training(split)
 
 # Create model and fit

--- a/inst/extdata-scripts/elnet.R
+++ b/inst/extdata-scripts/elnet.R
@@ -3,7 +3,7 @@ suppressWarnings(suppressMessages(library(parsnip)))
 suppressWarnings(suppressMessages(library(rsample)))
 
 # Load data
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 
 # Create model and fit

--- a/inst/extdata-scripts/kknn.R
+++ b/inst/extdata-scripts/kknn.R
@@ -5,7 +5,7 @@ suppressWarnings(suppressMessages(library(rpart)))
 
 # Load data
 set.seed(1234)
-split <- initial_split(kyphosis, props = 9/10)
+split <- initial_split(kyphosis, prop = 9/10)
 spine_train <- training(split)
 
 # Create model and fit

--- a/inst/extdata-scripts/lm.R
+++ b/inst/extdata-scripts/lm.R
@@ -3,7 +3,7 @@ suppressWarnings(suppressMessages(library(parsnip)))
 suppressWarnings(suppressMessages(library(rsample)))
 
 # Load data
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 car_test  <- testing(split)
 

--- a/inst/extdata-scripts/randomForest.R
+++ b/inst/extdata-scripts/randomForest.R
@@ -5,7 +5,7 @@ suppressWarnings(suppressMessages(library(rpart)))
 
 # Load data
 set.seed(1234)
-split <- initial_split(kyphosis, props = 9/10)
+split <- initial_split(kyphosis, prop = 9/10)
 spine_train <- training(split)
 
 # Create model and fit

--- a/inst/extdata-scripts/ranger.R
+++ b/inst/extdata-scripts/ranger.R
@@ -4,7 +4,7 @@ suppressWarnings(suppressMessages(library(rsample)))
 
 # Load data
 set.seed(1234)
-split <- initial_split(iris, props = 9/10)
+split <- initial_split(iris, prop = 9/10)
 iris_train <- training(split)
 
 # Create model and fit

--- a/inst/extdata-scripts/rpart.R
+++ b/inst/extdata-scripts/rpart.R
@@ -5,7 +5,7 @@ suppressWarnings(suppressMessages(library(rpart)))
 
 # Load data
 set.seed(1234)
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 
 # Create model and fit

--- a/inst/extdata-scripts/stanreg.R
+++ b/inst/extdata-scripts/stanreg.R
@@ -3,7 +3,7 @@ suppressWarnings(suppressMessages(library(parsnip)))
 suppressWarnings(suppressMessages(library(tidymodels)))
 
 # Load data
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 car_test  <- testing(split)
 

--- a/man/axe-C5.0.Rd
+++ b/man/axe-C5.0.Rd
@@ -39,7 +39,7 @@ library(rpart)
 
 # Load data
 set.seed(1234)
-split <- initial_split(kyphosis, props = 9/10)
+split <- initial_split(kyphosis, prop = 9/10)
 spine_train <- training(split)
 
 # Create model and fit

--- a/man/axe-elnet.Rd
+++ b/man/axe-elnet.Rd
@@ -30,7 +30,7 @@ library(parsnip)
 library(rsample)
 
 # Load data
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 
 # Create model and fit

--- a/man/axe-kknn.Rd
+++ b/man/axe-kknn.Rd
@@ -40,7 +40,7 @@ library(kknn)
 
 # Load data
 set.seed(1234)
-split <- initial_split(kyphosis, props = 9/10)
+split <- initial_split(kyphosis, prop = 9/10)
 spine_train <- training(split)
 
 # Create model and fit

--- a/man/axe-lm.Rd
+++ b/man/axe-lm.Rd
@@ -35,7 +35,7 @@ library(parsnip)
 library(rsample)
 
 # Load data
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 
 # Create model and fit

--- a/man/axe-randomForest.Rd
+++ b/man/axe-randomForest.Rd
@@ -41,7 +41,7 @@ data(kyphosis, package = "rpart")
 
 # Load data
 set.seed(1234)
-split <- initial_split(kyphosis, props = 9/10)
+split <- initial_split(kyphosis, prop = 9/10)
 spine_train <- training(split)
 
 # Create model and fit

--- a/man/axe-ranger.Rd
+++ b/man/axe-ranger.Rd
@@ -40,7 +40,7 @@ library(ranger)
 
 # Load data
 set.seed(1234)
-split <- initial_split(iris, props = 9/10)
+split <- initial_split(iris, prop = 9/10)
 iris_train <- training(split)
 
 # Create model and fit

--- a/man/axe-rpart.Rd
+++ b/man/axe-rpart.Rd
@@ -42,7 +42,7 @@ library(rpart)
 
 # Load data
 set.seed(1234)
-split <- initial_split(mtcars, props = 9/10)
+split <- initial_split(mtcars, prop = 9/10)
 car_train <- training(split)
 
 # Create model and fit


### PR DESCRIPTION
Several examples used `rsample::initial_split()` with an argument `props` which is a misspelling of the actual argument name `prop`. 

This got surfaced in https://github.com/tidymodels/rsample/pull/429 where we now check the dots more tightly.