### PR TITLE
Fix docs (especially for `coxph`) and UI messaging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,4 +82,5 @@ Config/Needs/check:
     bioc::mixOmics
 Config/testthat/edition: 3
 Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Updated methods for `mgcv::gam()` to also remove the `hat` and `offset` 
   components (@rdavis120, #255).
+  
+* Clarified the messaging for butchering results, as well as when butchering 
+  may not work for `survival::coxph()` (#261).
 
 # butcher 0.3.2
 

--- a/R/coxph.R
+++ b/R/coxph.R
@@ -4,6 +4,37 @@
 #'
 #' @return Axed coxph object.
 #'
+#' @details
+#' The [survival::coxph()] model is unique in how it uses environments in
+#' its components, and butchering such an object can behave in surprising ways
+#' in any environment other than the
+#' [global environment](https://adv-r.hadley.nz/environments.html#important-environments)
+#' (such as when wrapped in a function). We do not recommend that you use
+#'  `butcher()` with a `coxph` object anywhere other than the global environment.
+#'
+#'  Do this:
+#'
+#' ```r
+#' my_coxph_func <- function(df) {
+#'     coxph(Surv(time, status) ~ x + strata(covar), df)
+#' }
+#' ## in global environment only:
+#' butcher(my_coxph_func(df))
+#' ```
+#'
+#' Do *not* do this:
+#'
+#' ```r
+#' my_coxph_func <- function(df) {
+#'     res <- coxph(Surv(time, status) ~ x + strata(covar), df)
+#'     ## no:
+#'     butcher(res)
+#' }
+#'
+#' ## will not work correctly:
+#' my_coxph_func(df)
+#' ```
+#'
 #' @examplesIf rlang::is_installed("survival")
 #' library(survival)
 #'

--- a/R/ui.R
+++ b/R/ui.R
@@ -35,9 +35,9 @@ assess_object <- function(og, butchered) {
   } else {
     abs_mem <- format(abs(mem), big.mark = ",", scientific = FALSE)
     if (mem < 0) {
-      cli::cli_alert_danger("The butchered object is {.val {abs_mem}} larger than the original. Do not butcher.")
+      cli::cli_alert_danger("The butchered object is {.field {abs_mem}} larger than the original. Do not butcher.")
     } else {
-      cli::cli_alert_success("Memory released: {.val {abs_mem}}")
+      cli::cli_alert_success("Memory released: {.field {abs_mem}}")
       if (!is.null(disabled)) {
         cli::cli_alert_danger("Disabled: {.code {disabled}}")
       }

--- a/R/ui.R
+++ b/R/ui.R
@@ -15,13 +15,11 @@ memory_released <- function(og, butchered) {
   old <- lobstr::obj_size(og)
   new <- lobstr::obj_size(butchered)
   rel <- old - new
-  rel <- format(rel, big.mark = ",", scientific = FALSE)
   if (length(rel) == 1) {
-    if (rel <= 0) {
+    if (isTRUE(all.equal(old, new))) {
       return(NULL)
-    } else {
-      return(rel)
     }
+    return(rel)
   } else {
     return(NULL)
   }
@@ -35,13 +33,18 @@ assess_object <- function(og, butchered) {
   if (is.null(mem)) {
     cli::cli_alert_danger("No memory released. Do not butcher.")
   } else {
-    cli::cli_alert_success("Memory released: {.val {mem}}")
-    if (!is.null(disabled)) {
-      cli::cli_alert_danger("Disabled: {.code {disabled}}")
-    }
-    if (length(class_added) == 0) {
-      class_name <- "butchered"
-      cli::cli_alert_danger("Could not add {.cls {class_name}} class")
+    mem <- format(abs(mem), big.mark = ",", scientific = FALSE)
+    if (mem < 0) {
+      cli::cli_alert_danger("The butchered object is {.val {mem}} larger than the original. Do not butcher.")
+    } else {
+      cli::cli_alert_success("Memory released: {.val {mem}}")
+      if (!is.null(disabled)) {
+        cli::cli_alert_danger("Disabled: {.code {disabled}}")
+      }
+      if (length(class_added) == 0) {
+        class_name <- "butchered"
+        cli::cli_alert_danger("Could not add {.cls {class_name}} class")
+      }
     }
   }
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -33,11 +33,11 @@ assess_object <- function(og, butchered) {
   if (is.null(mem)) {
     cli::cli_alert_danger("No memory released. Do not butcher.")
   } else {
-    mem <- format(abs(mem), big.mark = ",", scientific = FALSE)
+    abs_mem <- format(abs(mem), big.mark = ",", scientific = FALSE)
     if (mem < 0) {
-      cli::cli_alert_danger("The butchered object is {.val {mem}} larger than the original. Do not butcher.")
+      cli::cli_alert_danger("The butchered object is {.val {abs_mem}} larger than the original. Do not butcher.")
     } else {
-      cli::cli_alert_success("Memory released: {.val {mem}}")
+      cli::cli_alert_success("Memory released: {.val {abs_mem}}")
       if (!is.null(disabled)) {
         cli::cli_alert_danger("Disabled: {.code {disabled}}")
       }

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To remove this (mostly) extraneous component, we can use `axe_env()`:
 
 ``` r
 cleaned_lm <- butcher::axe_env(big_lm, verbose = TRUE)
-#> ✔ Memory released: "8.03 MB"
+#> ✔ Memory released: 8.03 MB
 ```
 
 Comparing it against our `small_lm`, we’ll find:

--- a/man/axe-coxph.Rd
+++ b/man/axe-coxph.Rd
@@ -25,6 +25,35 @@ Axed coxph object.
 \description{
 Axing a coxph.
 }
+\details{
+The \code{\link[survival:coxph]{survival::coxph()}} model is unique in how it uses environments in
+its components, and butchering such an object can behave in surprising ways
+in any environment other than the
+\href{https://adv-r.hadley.nz/environments.html#important-environments}{global environment}
+(such as when wrapped in a function). We do not recommend that you use
+\code{butcher()} with a \code{coxph} object anywhere other than the global environment.
+
+Do this:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_coxph_func <- function(df) \{
+    coxph(Surv(time, status) ~ x + strata(covar), df)
+\}
+## in global environment only:
+butcher(my_coxph_func(df))
+}\if{html}{\out{</div>}}
+
+Do \emph{not} do this:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{my_coxph_func <- function(df) \{
+    res <- coxph(Surv(time, status) ~ x + strata(covar), df)
+    ## no:
+    butcher(res)
+\}
+
+## will not work correctly:
+my_coxph_func(df)
+}\if{html}{\out{</div>}}
+}
 \examples{
 \dontshow{if (rlang::is_installed("survival")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(survival)

--- a/man/axe-ipred.Rd
+++ b/man/axe-ipred.Rd
@@ -53,10 +53,10 @@ disabled. Default is \code{FALSE}.}
 \item{...}{Any additional arguments related to axing.}
 }
 \value{
-Axed `*_bagg` object.
+Axed \verb{*_bagg} object.
 }
 \description{
-`*_bagg` objects are created from the \pkg{ipred} package, which
+\verb{*_bagg} objects are created from the \pkg{ipred} package, which
 is used for bagging classification, regression and survival trees.
 }
 \examples{

--- a/man/axe-nested_model_fit.Rd
+++ b/man/axe-nested_model_fit.Rd
@@ -55,5 +55,5 @@ butcher(fit)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-[axe-model_fit]
+\link{axe-model_fit}
 }

--- a/man/axe-pls.Rd
+++ b/man/axe-pls.Rd
@@ -33,16 +33,16 @@ disabled. Default is \code{FALSE}.}
 \item{...}{Any additional arguments related to axing.}
 }
 \value{
-Axed `mixo_pls`, `mixo_spls`, or `mixo_plsda` object.
+Axed \code{mixo_pls}, \code{mixo_spls}, or \code{mixo_plsda} object.
 }
 \description{
-`mixo_pls` (via `pls()`), `mixo_spls` (via `spls()`), and `mixo_plsda`
-(via `plsda()`) objects are created with the mixOmics package,
+\code{mixo_pls} (via \code{pls()}), \code{mixo_spls} (via \code{spls()}), and \code{mixo_plsda}
+(via \code{plsda()}) objects are created with the mixOmics package,
 leveraged to fit partial least squares models.
 }
 \details{
 The mixOmics package is not available on CRAN, but can be installed
-from the Bioconductor repository via `remotes::install_bioc("mixOmics")`.
+from the Bioconductor repository via \code{remotes::install_bioc("mixOmics")}.
 }
 \examples{
 \dontshow{if (rlang::is_installed("mixOmics")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/butcher-package.Rd
+++ b/man/butcher-package.Rd
@@ -13,11 +13,11 @@ should support additional analysis functions outside of just \code{predict}.
 
 This package provides five S3 generics:
 \itemize{
-  \item \code{\link{axe_call}} To remove the call object.
-  \item \code{\link{axe_ctrl}} To remove controls associated with training.
-  \item \code{\link{axe_data}} To remove the original data.
-  \item \code{\link{axe_env}} To remove inherited environments.
-  \item \code{\link{axe_fitted}} To remove fitted values.
+\item \code{\link{axe_call}} To remove the call object.
+\item \code{\link{axe_ctrl}} To remove controls associated with training.
+\item \code{\link{axe_data}} To remove the original data.
+\item \code{\link{axe_env}} To remove inherited environments.
+\item \code{\link{axe_fitted}} To remove fitted values.
 }
 
 These specific attributes of the model objects are chosen as they are

--- a/man/butcher_example.Rd
+++ b/man/butcher_example.Rd
@@ -7,10 +7,10 @@
 butcher_example(path = NULL)
 }
 \arguments{
-\item{path}{Name of file. If `NULL`, the example files will be listed.}
+\item{path}{Name of file. If \code{NULL}, the example files will be listed.}
 }
 \description{
-butcher comes bundled with some example files in its `inst/extdata`
+butcher comes bundled with some example files in its \code{inst/extdata}
 directory. This function was copied from readxl and placed here to
 make the instantiated model objects easy to access.
 }

--- a/man/new_model_butcher.Rd
+++ b/man/new_model_butcher.Rd
@@ -18,11 +18,11 @@ opens the new files for editing.}
 }
 \description{
 \code{new_model_butcher()} will instantiate the following to help
-  us develop new axe functions around removing parts of a new
-  modeling object:
+us develop new axe functions around removing parts of a new
+modeling object:
 \itemize{
-  \item Add modeling package to \code{Suggests}
-  \item Generate and populate an axe file under \code{R/}
-  \item Generate and populate an test file under \code{testthat/}
+\item Add modeling package to \code{Suggests}
+\item Generate and populate an axe file under \code{R/}
+\item Generate and populate an test file under \code{testthat/}
 }
 }

--- a/tests/testthat/_snaps/ui.md
+++ b/tests/testthat/_snaps/ui.md
@@ -3,7 +3,7 @@
     Code
       assess_object(big, small)
     Message
-      v Memory released: "<redacted>"
+      v Memory released: <redacted>
     Code
       assess_object(small, small)
     Message
@@ -11,5 +11,5 @@
     Code
       assess_object(small, big)
     Message
-      x The butchered object is "<redacted>" larger than the original. Do not butcher.
+      x The butchered object is <redacted> larger than the original. Do not butcher.
 

--- a/tests/testthat/_snaps/ui.md
+++ b/tests/testthat/_snaps/ui.md
@@ -1,0 +1,15 @@
+# Generate expected UI messages
+
+    Code
+      assess_object(big, small)
+    Message
+      v Memory released: "72 kB"
+    Code
+      assess_object(small, small)
+    Message
+      x No memory released. Do not butcher.
+    Code
+      assess_object(small, big)
+    Message
+      v Memory released: "72 kB"
+

--- a/tests/testthat/_snaps/ui.md
+++ b/tests/testthat/_snaps/ui.md
@@ -3,7 +3,7 @@
     Code
       assess_object(big, small)
     Message
-      v Memory released: "72 kB"
+      v Memory released: "<redacted>"
     Code
       assess_object(small, small)
     Message
@@ -11,5 +11,5 @@
     Code
       assess_object(small, big)
     Message
-      v Memory released: "72 kB"
+      v Memory released: "<redacted>"
 

--- a/tests/testthat/_snaps/ui.md
+++ b/tests/testthat/_snaps/ui.md
@@ -11,5 +11,5 @@
     Code
       assess_object(small, big)
     Message
-      v Memory released: "<redacted>"
+      x The butchered object is "<redacted>" larger than the original. Do not butcher.
 

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -1,0 +1,13 @@
+test_that("Generate expected UI messages", {
+  big <- runif(1e4)
+  big <- add_butcher_class(big)
+  small <- runif(1e3)
+  small <- add_butcher_class(small)
+
+  expect_snapshot({
+    assess_object(big, small)
+    assess_object(small, small)
+    assess_object(small, big)
+  })
+
+})

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -3,11 +3,15 @@ test_that("Generate expected UI messages", {
   big <- add_butcher_class(big)
   small <- runif(1e3)
   small <- add_butcher_class(small)
+  obj_size_diff <- lobstr::obj_size(big) - lobstr::obj_size(small)
+  obj_size_diff <- format(obj_size_diff, big.mark = ",", scientific = FALSE)
 
   expect_snapshot({
     assess_object(big, small)
     assess_object(small, small)
     assess_object(small, big)
-  })
-
+  },
+  transform = function(snapshot)
+    gsub(obj_size_diff, "<redacted>", snapshot, fixed = TRUE)
+  )
 })

--- a/tests/testthat/test-ui.R
+++ b/tests/testthat/test-ui.R
@@ -11,7 +11,6 @@ test_that("Generate expected UI messages", {
     assess_object(small, small)
     assess_object(small, big)
   },
-  transform = function(snapshot)
-    gsub(obj_size_diff, "<redacted>", snapshot, fixed = TRUE)
+  transform = function(x) gsub(obj_size_diff, "<redacted>", x, fixed = TRUE)
   )
 })


### PR DESCRIPTION
Closes #260 

This PR mainly

- adds a disclaimer to the `coxph` docs about not using butcher from anywhere but the global env
- changes the UI messaging to tell folks when their butchered object is actually _larger_

Turns out we didn't have `markdown = TRUE` set yet so this PR makes that change and updates the needed docs as well.