### PR TITLE
Fix butchering for parsnip's `bart()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Clarified the messaging for butchering results, as well as when butchering 
   may not work for `survival::coxph()` (#261).
 
+* Fixed a bug in butchering BART models (#263).
+
 # butcher 0.3.2
 
 * Added butcher methods for `mixOmics::pls()`, `mixOmics::spls()`, 

--- a/R/bart.R
+++ b/R/bart.R
@@ -37,7 +37,6 @@ axe_fitted.bart <- function(x, verbose = FALSE, ...) {
     res <- exchange(res, "yhat.test", numeric(0))
     res <- exchange(res, "yhat.test.mean", numeric(0))
   }
-  res <- exchange(res, "sigma", numeric(0))
   res <- exchange(res, "varcount", numeric(0))
 
   add_butcher_attributes(

--- a/tests/testthat/test-bart.R
+++ b/tests/testthat/test-bart.R
@@ -1,4 +1,5 @@
 skip_if_not_installed("dbarts")
+skip_if_not_installed("parsnip")
 
 test_that("dbarts + axe_call() works", {
   res <- dbarts::bart(mtcars[,2:5], mtcars[,1], verbose = FALSE)
@@ -13,7 +14,6 @@ test_that("dbarts + axe_fitted() works", {
   expect_equal(x$yhat.train.mean, numeric(0))
   expect_equal(x$yhat.test, numeric(0))
   expect_equal(x$yhat.test.mean, numeric(0))
-  expect_equal(x$sigma, numeric(0))
   expect_equal(x$varcount, numeric(0))
 })
 
@@ -31,5 +31,23 @@ test_that("dbarts + predict() works", {
   expect_equal(
     predict(x, newdata = head(mtcars))[1],
     predict(res, newdata = head(mtcars))[1]
+  )
+  expect_equal(
+    mean(predict(x, newdata = head(mtcars), type = "ppd")),
+    mean(predict(res, newdata = head(mtcars), type = "ppd")),
+    tolerance = 0.1
+  )
+})
+
+test_that("bart() from parsnip + predict() works", {
+  library(parsnip)
+  spec <- bart(mode = "regression", trees = 5)
+  res <- fit(spec, mpg ~ ., mtcars)
+  x <- butcher(res)
+
+  expect_equal(
+    mean(predict(x, new_data = head(mtcars))$.pred),
+    mean(predict(res, new_data = head(mtcars))$.pred),
+    tolerance = 0.1
   )
 })

--- a/tests/testthat/test-bart.R
+++ b/tests/testthat/test-bart.R
@@ -50,4 +50,14 @@ test_that("bart() from parsnip + predict() works", {
     mean(predict(res, new_data = head(mtcars))$.pred),
     tolerance = 0.1
   )
+  expect_equal(
+    mean(predict(x, new_data = head(mtcars), type = "conf_int")$.pred_lower),
+    mean(predict(res, new_data = head(mtcars), type = "conf_int")$.pred_lower),
+    tolerance = 0.1
+  )
+  expect_equal(
+    mean(predict(x, new_data = head(mtcars), type = "pred_int")$.pred_lower),
+    mean(predict(res, new_data = head(mtcars), type = "pred_int")$.pred_lower),
+    tolerance = 0.1
+  )
 })


### PR DESCRIPTION
Closes #262 

Turns out we need that `sigma` slot for predicting with `type = "ppd"` as well as for parsnip' `bart()`.