### PR TITLE
allow R CMD check on `workflow_dispatch`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -9,6 +9,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 name: R-CMD-check
 


### PR DESCRIPTION
Mostly just a reason to run GHA to see if https://github.com/tidymodels/stacks/issues/217 is replicable without stacks.

This `on:` entry allows for rerunning actions without changes. :)

