### PR TITLE
Remove clisymbols from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,6 @@ Imports:
 Suggests: 
     C50,
     caret,
-    clisymbols,
     ClusterR,
     clustMixType,
     covr,

--- a/vignettes/available-axe-methods.Rmd
+++ b/vignettes/available-axe-methods.Rmd
@@ -11,8 +11,7 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = requireNamespace("dplyr", quietly = TRUE) & 
-         requireNamespace("clisymbols", quietly = TRUE)
+  eval = requireNamespace("dplyr", quietly = TRUE)
 )
 ```
 
@@ -21,12 +20,11 @@ The following axe methods are currently available in butcher:
 ```{r setup, echo = FALSE, warnings = FALSE, message = FALSE}
 suppressWarnings(library(butcher))
 suppressWarnings(library(dplyr))
-suppressWarnings(library(clisymbols))
 
 method_df <- function(method_name) {
   m <- as.vector(utils::methods(method_name))
   tibble::tibble(class = gsub(paste0(method_name, "[.]"), "", m),
-                 !!method_name := clisymbols::symbol$tick)
+                 !!method_name := cli::symbol$tick)
 }
 
 replace_na <- function(x) {


### PR DESCRIPTION
since `cli::symbol` is exported and cli is imported by butcher