### PR TITLE
Remove dimRed from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,6 @@ Suggests:
     covr,
     dbarts,
     ddalpha,
-    dimRed,
     dplyr,
     e1071,
     earth,


### PR DESCRIPTION
Looks like [dimRed has gotten the axe](https://cran.r-project.org/package=dimRed). 😩 

I believe we had this for its use in recipes, and seems like at least the direct uses of it were taken out a while back in https://github.com/tidymodels/recipes/pull/829.