### PR TITLE
Reduce flakiness of tests

### DIFF
--- a/tests/testthat/test-ipred.R
+++ b/tests/testthat/test-ipred.R
@@ -70,6 +70,7 @@ test_that("ipred + rpart + axing works (survbagg)", {
         MGEc.10 +
         IPI,
       data = DLBCL,
+      nbagg = 30L,
       coob = TRUE
     )
 
@@ -136,9 +137,10 @@ test_that("ipred + rpart + predict() works (classbagg)", {
     fit$mtrees[[1]]$btree$control$usesurrogate
   )
 
+  # fix seed in case of random tiebreaker in predict.classbagg
   expect_equal(
-    predict(x, data.frame(x = 1)),
-    predict(fit, data.frame(x = 1))
+    withr::with_seed(123, predict(x, data.frame(x = 1))),
+    withr::with_seed(123, predict(fit, data.frame(x = 1)))
   )
 })
 
@@ -157,6 +159,7 @@ test_that("ipred + rpart + predict() works (survbagg)", {
         MGEc.10 +
         IPI,
       data = DLBCL,
+      nbagg = 30L,
       coob = TRUE
     )
 


### PR DESCRIPTION
I observed 1-2% flakiness in the test suite.

 - The default `nbagg = 25L` produces a never-out-of-bag observation about .05% of the time, n=30 should be about an order magnitude rarer and not slow down the test much
 - [{ipred}'s `predict.classbagg` method uses `sample()` in the case of ties](https://codeberg.org/thothorn/ipred/src/commit/d0199232dd65e13cdd6e6e07f80505445b712971/R/predict.bagging.R#L7), leading to a 1-2% rate of the predictions differing purely by chance. (I suppose an alternative is to use a different `aggregation=`)

All told I see 1/10000 failure with this change (the 1 would go away at `nbagg=35L`)